### PR TITLE
Bugfix/fix bugs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "dependencies/rapidjson"]
 	path = dependencies/rapidjson
 	url = https://github.com/Tencent/rapidjson
-[submodule "dependencies/glaze"]
-	path = dependencies/glaze
-	url = https://github.com/stephenberry/glaze

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "dependencies/rapidjson"]
 	path = dependencies/rapidjson
 	url = https://github.com/Tencent/rapidjson
+[submodule "dependencies/glaze"]
+	path = dependencies/glaze
+	url = https://github.com/stephenberry/glaze

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "dependencies/hopscotch-map"]
 	path = dependencies/hopscotch-map
 	url = https://github.com/Tessil/hopscotch-map
-[submodule "dependencies/mimalloc"]
-	path = dependencies/mimalloc
-	url = https://github.com/microsoft/mimalloc
 [submodule "dependencies/googletest"]
 	path = dependencies/googletest
 	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ add_git_submodule("${PROJECT_SOURCE_DIR}/dependencies/glaze")
 
 if (UNIX)
         if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        add_compile_options(-Ofast -fno-exceptions -fno-builtin-malloc)
+        add_compile_options(-Ofast -fno-exceptions)
         endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,7 @@ set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
 add_git_submodule("${PROJECT_SOURCE_DIR}/dependencies/rapidjson")
 
-set(MI_OVERRIDE OFF CACHE BOOL "" FORCE)
-set(MI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-
-add_git_submodule("${PROJECT_SOURCE_DIR}/dependencies/mimalloc")
+add_git_submodule("${PROJECT_SOURCE_DIR}/dependencies/glaze")
 
 if (UNIX)
         if (CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -64,10 +61,9 @@ endif()
 include_directories($CACHE{INCLUDE_PATH})
 
 add_library(BlazeFS "$CACHE{SOURCE_PATH}/BlazeFS.cpp")
-target_link_libraries(BlazeFS PUBLIC mimalloc)
 include_directories("${PROJECT_SOURCE_DIR}/dependencies/rapidjson/include")
 include_directories("${PROJECT_SOURCE_DIR}/dependencies/hopscotch-map/include")
-include_directories("${PROJECT_SOURCE_DIR}/dependencies/mimalloc/include")
+include_directories("${PROJECT_SOURCE_DIR}/dependencies/glaze/include")
 
 if (BUILD_EXAMPLES)
         add_executable(example_write_read_file "$CACHE{EXAMPLES_PATH}/main.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
 add_git_submodule("${PROJECT_SOURCE_DIR}/dependencies/rapidjson")
 
-add_git_submodule("${PROJECT_SOURCE_DIR}/dependencies/glaze")
-
 if (UNIX)
         if (CMAKE_BUILD_TYPE STREQUAL "Release")
         add_compile_options(-Ofast -fno-exceptions)
@@ -63,7 +61,6 @@ include_directories($CACHE{INCLUDE_PATH})
 add_library(BlazeFS "$CACHE{SOURCE_PATH}/BlazeFS.cpp")
 include_directories("${PROJECT_SOURCE_DIR}/dependencies/rapidjson/include")
 include_directories("${PROJECT_SOURCE_DIR}/dependencies/hopscotch-map/include")
-include_directories("${PROJECT_SOURCE_DIR}/dependencies/glaze/include")
 
 if (BUILD_EXAMPLES)
         add_executable(example_write_read_file "$CACHE{EXAMPLES_PATH}/main.cpp")

--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ Also, when we are constructing filesystem, we can pre-allocate space in `/` like
 blazefs::BlazeFS filesystem(1024);
 ```
 
+### Changing directory
+
+You can change directory by using `cd` function, like so:
+
+```cpp
+
+filesystem.createDir("/myDir/");
+filesystem.write("/myDir/file", "something");
+filesystem.exists("file"); // Returns false, because we provide relative path, and current directory is /
+filesystem.cd("/myDir/");
+filesystem.exists("file"); // Returns true, as we've changed current directory
+
+```
+
 ## Used libraries
 - [hopschotch-map](https://github.com/Tessil/hopscotch-map)
 - [mimalloc](https://github.com/microsoft/mimalloc)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ filesystem.write("/test.txt", "Hello World");
 filesystem.write("./test.txt", "Hello World");
 ```
 
+If you need, you can specify second template parameter which `false` by default. When this is `true`, writing will be available only from current directory, but this allows to skip path parsing which leads to significant performance boost. Also, all data validation checks will not be used, so your code may become more unstable. Use only if you are sure that there will be only correct data provided.
+
+```cpp
+filesystem.write<std::string, true>("file_with_string", std::string("something"));
+```
+
 ### Directory creation
 
 We can create directory by using function `createDir()`:
@@ -88,6 +94,12 @@ filesystem.read<myStruct>("file_with_struct"); // OK, we wrote myStruct and are 
 filesystem.read<const char*>("file_with_string"); // std::bad_any_cast, trying to read const char* where we wrote std::string
 ```
 
+If you need, you can specify second template parameter which `false` by default. When this is `true`, reading will be available only from current directory, but this allows to skip path parsing which leads to significant performance boost. Also, all data validation checks will not be used, so your code may become more unstable. Use only if you are sure that there will be only correct data provided.
+
+```cpp
+filesystem.read<std::string, true>("file_with_string");
+```
+
 ### Reserve
 If we want to write a lot of files into one folder, we can use `reserve` to pre-allocate memory and speed-up insertion:
 ```cpp
@@ -118,7 +130,6 @@ filesystem.exists("file"); // Returns true, as we've changed current directory
 
 ## Used libraries
 - [hopschotch-map](https://github.com/Tessil/hopscotch-map)
-- [mimalloc](https://github.com/microsoft/mimalloc)
 - [rapidjson](https://rapidjson.org/) (used only for parsing asar)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ struct myStruct {
 // ...
 myStruct myStructObj;
 
-filesystem.write("file_with_string", std::string("something));
+filesystem.write("file_with_string", std::string("something"));
 filesystem.write("file_with_struct", myStructObj);
 
 filesystem.read<std::string>("file_with_string"); // OK, we wrote std::string and are reading std string

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mkdir build && cd build
 cmake ..
 make -j4
 ```
-If you are on Windows, cmake will create a `.sln` project file instead of `makefile`, that you can open in Visual Studio, or build from commandline using
+If you are on Windows, cmake will create a `.sln` project file instead of `makefile`, that you can open in Visual Studio, or build from command line using
 ```
 msbuild blazefs.sln -m /property:Configuration=Release
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ As I was benchmarking, vfs outperforms STL containers such as `std::map<std::str
 This project is linux-first, but also working on Windows and MacOS. If you find some bugs, want to get new feature or something like this, open issue using template and provide your ideas and information.
 ## How it's working?
 **BlazeFS** uses `tsl::bhopscotch_map` to store tree. Directory and file names are treated as `std::string` key, and data as `std::any`, so you can store anything as long as it can be casted in and from `std::any`. This project can be used even for big filesystem, because it uses smart pointers, which mean that there will be no chance for memory leaks etc.
-## How to build and use
+## How to build
 This project uses cmake as build system, so clone the repository and just do in the terminal:
 ```
 mkdir build && cd build
@@ -35,7 +35,72 @@ If you are on Windows, cmake will create a `.sln` project file instead of `makef
 msbuild blazefs.sln -m /property:Configuration=Release
 ```
 
-For examples just look in the repository.
+## Usage
+You can initialize filesystem just using
+```cpp
+blazefs::BlazeFS filesystem;
+```
+### Writing
+For example, we want to write file `test.txt` with content `Hello World`. We can do that in several ways:
+1. Write in the current directory. By default, current directory is `/`
+```cpp
+filesystem.write("test.txt", "Hello World");
+```
+2. Write in the `/` directly:
+```cpp
+filesystem.write("/test.txt", "Hello World");
+```
+3. Write into that folder using `./`:
+```cpp
+filesystem.write("./test.txt", "Hello World");
+```
+
+### Directory creation
+
+We can create directory by using function `createDir()`:
+```cpp
+filesystem.createDir("dir1/");
+filesystem.createDir("/dir2/");
+filesystem.createDir("./dir3/");
+```
+This will create 3 directories that will be placed in the `/`. If you changed dir using `cd` previously, then only `dir2/` will be placed in the `/`.
+
+### Reading
+This is the same as writing, but for reading we also have to provide what type is written into file. For example:
+```cpp
+
+struct myStruct {
+
+    int a;
+    std::string b;
+
+};
+
+// ...
+myStruct myStructObj;
+
+filesystem.write("file_with_string", std::string("something));
+filesystem.write("file_with_struct", myStructObj);
+
+filesystem.read<std::string>("file_with_string"); // OK, we wrote std::string and are reading std string
+filesystem.read<myStruct>("file_with_struct"); // OK, we wrote myStruct and are reading myStruct
+
+filesystem.read<const char*>("file_with_string"); // std::bad_any_cast, trying to read const char* where we wrote std::string
+```
+
+### Reserve
+If we want to write a lot of files into one folder, we can use `reserve` to pre-allocate memory and speed-up insertion:
+```cpp
+
+filesystem.createDir("myDir/"); // create dir where we want to insert a lot of files
+filesystem.reserve("mydir/", 1024); // Reserving space for 1024 files
+
+```
+
+Also, when we are constructing filesystem, we can pre-allocate space in `/` like so:
+```cpp
+blazefs::BlazeFS filesystem(1024);
+```
 
 ## Used libraries
 - [hopschotch-map](https://github.com/Tessil/hopscotch-map)

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -35,7 +35,7 @@ void func() {
     std::cout << "";
 }
 
-int main(int argc, const char *argv[]) {
+int main(int, char **) {
 
     blaze::BlazeFS filesystem;
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,6 +1,9 @@
+#include <iomanip>
 #include <iostream>
-#include "BlazeFS/BlazeFS.hpp"
+#include <unordered_map>
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
+/*
 int main() {
 
     // Creating filesystem object
@@ -23,6 +26,79 @@ int main() {
     // std::cout << filesystem.read<std::string>("./file");
 
     std::cout << filesystem.read<std::string>("file") << std::endl;
+
+    return 0;
+}*/
+
+void func() {
+
+    std::cout << "";
+}
+
+int main(int argc, const char *argv[]) {
+
+    blaze::BlazeFS filesystem;
+
+    /*filesystem.readArchive("app.asar");
+
+    auto dirListing = filesystem.listDir("/");
+
+    // std::cout << dirListing->size() << std::endl;
+
+    for (const auto &entry : *dirListing) std::cout << entry << '\n';
+
+    auto subDirListing = filesystem.listDir("assets/");
+
+    std::cout << "\n------------------\n";
+
+    for (const auto &entry : *subDirListing) std::cout << entry << '\n';*/
+
+    clock_t before, after;
+
+    // std::vector<std::string> iStr;
+
+    // before = clock();
+    // for (std::uint64_t i = 0; i < 10'000'000; ++i)
+    //     iStr.emplace_back(std::to_string(i));
+    // after = clock();
+
+    // std::cout << std::fixed << std::setprecision(6)
+    //           << double(after - before) / CLOCKS_PER_SEC
+    //           << "s for vector write\n";
+
+
+    filesystem.reserve("/", 10'000'000);
+
+    before = clock();
+    for (std::uint64_t i = 0; i < 10'000'000; ++i)
+        // filesystem.write<std::uint64_t, true>(iStr[i], i);
+        filesystem.write<std::uint64_t, true>(std::to_string(i), i);
+    after = clock();
+
+    std::cout << std::fixed << std::setprecision(6)
+              << double(after - before) / CLOCKS_PER_SEC << "s for vfs write\n";
+
+    before = clock();
+    for (std::uint64_t i = 0; i < 10'000'000; ++i)
+        // filesystem.read<std::uint64_t, true>(iStr[i]);
+        filesystem.read<std::uint64_t, true>(std::to_string(i));
+    // func();
+    after = clock();
+
+    std::cout << std::fixed << std::setprecision(6)
+              << double(after - before) / CLOCKS_PER_SEC << "s for vfs read\n";
+
+
+    // std::map<std::string, std::uint64_t> map1;
+
+    // before = clock();
+    // for (std::uint64_t i = 0; i < 10'000'000; ++i)
+    //     map1.emplace(std::to_string(i), i);
+    // after = clock();
+
+    // std::cout << std::fixed << std::setprecision(6)
+    //           << double(after - before) / CLOCKS_PER_SEC
+    //           << "s for map without custom allocator write\n";
 
     return 0;
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,13 +1,11 @@
-#include <iomanip>
 #include <iostream>
-#include <unordered_map>
 #include "blaze/BlazeFS/BlazeFS.hpp"
 
-/*
+
 int main() {
 
     // Creating filesystem object
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
 
     // String that we will write to the file
     std::string myStr = "Hello World from Virtual filesystem!";
@@ -26,79 +24,6 @@ int main() {
     // std::cout << filesystem.read<std::string>("./file");
 
     std::cout << filesystem.read<std::string>("file") << std::endl;
-
-    return 0;
-}*/
-
-void func() {
-
-    std::cout << "";
-}
-
-int main(int, char **) {
-
-    blaze::BlazeFS filesystem;
-
-    /*filesystem.readArchive("app.asar");
-
-    auto dirListing = filesystem.listDir("/");
-
-    // std::cout << dirListing->size() << std::endl;
-
-    for (const auto &entry : *dirListing) std::cout << entry << '\n';
-
-    auto subDirListing = filesystem.listDir("assets/");
-
-    std::cout << "\n------------------\n";
-
-    for (const auto &entry : *subDirListing) std::cout << entry << '\n';*/
-
-    clock_t before, after;
-
-    // std::vector<std::string> iStr;
-
-    // before = clock();
-    // for (std::uint64_t i = 0; i < 10'000'000; ++i)
-    //     iStr.emplace_back(std::to_string(i));
-    // after = clock();
-
-    // std::cout << std::fixed << std::setprecision(6)
-    //           << double(after - before) / CLOCKS_PER_SEC
-    //           << "s for vector write\n";
-
-
-    filesystem.reserve("/", 10'000'000);
-
-    before = clock();
-    for (std::uint64_t i = 0; i < 10'000'000; ++i)
-        // filesystem.write<std::uint64_t, true>(iStr[i], i);
-        filesystem.write<std::uint64_t, true>(std::to_string(i), i);
-    after = clock();
-
-    std::cout << std::fixed << std::setprecision(6)
-              << double(after - before) / CLOCKS_PER_SEC << "s for vfs write\n";
-
-    before = clock();
-    for (std::uint64_t i = 0; i < 10'000'000; ++i)
-        // filesystem.read<std::uint64_t, true>(iStr[i]);
-        filesystem.read<std::uint64_t, true>(std::to_string(i));
-    // func();
-    after = clock();
-
-    std::cout << std::fixed << std::setprecision(6)
-              << double(after - before) / CLOCKS_PER_SEC << "s for vfs read\n";
-
-
-    // std::map<std::string, std::uint64_t> map1;
-
-    // before = clock();
-    // for (std::uint64_t i = 0; i < 10'000'000; ++i)
-    //     map1.emplace(std::to_string(i), i);
-    // after = clock();
-
-    // std::cout << std::fixed << std::setprecision(6)
-    //           << double(after - before) / CLOCKS_PER_SEC
-    //           << "s for map without custom allocator write\n";
 
     return 0;
 }

--- a/include/blaze/BlazeFS/BlazeFS.hpp
+++ b/include/blaze/BlazeFS/BlazeFS.hpp
@@ -9,9 +9,9 @@
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"
 
-#include "BlazeFS/internal/types.hpp"
+#include "blaze/BlazeFS/internal/types.hpp"
 
-namespace blazefs {
+namespace blaze {
 
     class BlazeFS {
 
@@ -24,9 +24,9 @@ namespace blazefs {
 
             std::ifstream m_ifsInputFile;
 
-            std::shared_ptr<blazefs::internal::fs_map> vfs_ptr =
-                std::make_shared<blazefs::internal::fs_map>();
-            std::shared_ptr<blazefs::internal::fs_map> cur_dir;
+            std::shared_ptr<blaze::internal::fs_map> vfs_ptr =
+                std::make_shared<blaze::internal::fs_map>();
+            std::shared_ptr<blaze::internal::fs_map> cur_dir;
 
             void unpackFiles(rapidjson::Value &object,
                              const std::string &sPath = "/") noexcept;
@@ -34,10 +34,10 @@ namespace blazefs {
             void unpackFilesMem(rapidjson::Value &object, std::uint8_t *buf,
                                 const std::string &sPath = "/") noexcept;
 
-            blazefs::internal::parsedPathObject
+            blaze::internal::parsedPathObject
                 parsePath(const std::string &path) noexcept;
 
-            blazefs::internal::parsedPathObject
+            blaze::internal::parsedPathObject
                 parseMkdirPath(const std::string &path) noexcept;
 
             bool mkdirWrite(const std::string &filename,
@@ -139,4 +139,4 @@ namespace blazefs {
         }
     }
 
-}; // namespace blazefs
+}; // namespace blaze

--- a/include/blaze/BlazeFS/internal/types.hpp
+++ b/include/blaze/BlazeFS/internal/types.hpp
@@ -6,7 +6,7 @@
 
 #include "tsl/bhopscotch_map.h"
 
-namespace blazefs {
+namespace blaze {
 
     namespace internal {
 
@@ -23,4 +23,4 @@ namespace blazefs {
 
     }; // namespace internal
 
-}; // namespace blazefs
+}; // namespace blaze

--- a/src/BlazeFS.cpp
+++ b/src/BlazeFS.cpp
@@ -123,6 +123,7 @@ namespace blaze {
         if (!res) { return false; }
 
         this->unpackFilesMem(json["files"], buf);
+
         m_szOffset = 0;
 
         delete[] headerBuf;

--- a/src/BlazeFS.cpp
+++ b/src/BlazeFS.cpp
@@ -1,13 +1,13 @@
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
-#include "mimalloc-new-delete.h"
+// #include "glaze/glaze.hpp"
 
 #define DIR_SEPARATOR '/'
 
 inline constexpr auto self = "./";
 inline constexpr auto prev = "../";
 
-namespace blazefs {
+namespace blaze {
 
 
     void BlazeFS::unpackFiles(rapidjson::Value &object,
@@ -160,10 +160,10 @@ namespace blazefs {
         cur_dir = vfs_ptr;
     }
 
-    blazefs::internal::parsedPathObject
+    blaze::internal::parsedPathObject
         BlazeFS::parseMkdirPath(const std::string &path) noexcept {
 
-        blazefs::internal::parsedPathObject ret;
+        blaze::internal::parsedPathObject ret;
 
         std::uint16_t i = 0;
 
@@ -183,12 +183,13 @@ namespace blazefs {
 
                 auto it = ret.ptr->find(tmp);
                 if (it != ret.ptr->end())
-                    ret.ptr = std::any_cast<
-                        std::shared_ptr<blazefs::internal::fs_map>>(it->second);
+                    ret.ptr =
+                        std::any_cast<std::shared_ptr<blaze::internal::fs_map>>(
+                            it->second);
                 else {
 
-                    std::shared_ptr<blazefs::internal::fs_map> directory =
-                        std::make_shared<blazefs::internal::fs_map>();
+                    std::shared_ptr<blaze::internal::fs_map> directory =
+                        std::make_shared<blaze::internal::fs_map>();
                     directory->emplace(self, directory);
                     directory->emplace(prev, ret.ptr);
 
@@ -209,10 +210,10 @@ namespace blazefs {
         return ret;
     }
 
-    blazefs::internal::parsedPathObject
+    blaze::internal::parsedPathObject
         BlazeFS::parsePath(const std::string &path) noexcept {
 
-        blazefs::internal::parsedPathObject ret;
+        blaze::internal::parsedPathObject ret;
 
         std::uint16_t i = 0;
 
@@ -232,8 +233,9 @@ namespace blazefs {
 
                 auto it = ret.ptr->find(tmp);
                 if (it != ret.ptr->end())
-                    ret.ptr = std::any_cast<
-                        std::shared_ptr<blazefs::internal::fs_map>>(it->second);
+                    ret.ptr =
+                        std::any_cast<std::shared_ptr<blaze::internal::fs_map>>(
+                            it->second);
                 else {
 
                     ret.status = false;
@@ -299,7 +301,7 @@ namespace blazefs {
         auto it = tmp.ptr->find(tmp.lastElement);
         if (it == tmp.ptr->end()) return false;
 
-        cur_dir = std::any_cast<std::shared_ptr<blazefs::internal::fs_map>>(
+        cur_dir = std::any_cast<std::shared_ptr<blaze::internal::fs_map>>(
             it->second);
 
         return true;
@@ -317,8 +319,8 @@ namespace blazefs {
 
         if (tmp.ptr->contains(tmp.lastElement)) return false;
 
-        std::shared_ptr<blazefs::internal::fs_map> directory =
-            std::make_shared<blazefs::internal::fs_map>();
+        std::shared_ptr<blaze::internal::fs_map> directory =
+            std::make_shared<blaze::internal::fs_map>();
         directory->emplace(self, directory);
         directory->emplace(prev, tmp.ptr);
 
@@ -332,15 +334,19 @@ namespace blazefs {
 
         if (dirname.empty()) return {};
 
-        auto tmp = this->parsePath(dirname);
+        blaze::internal::parsedPathObject tmp;
+        if (dirname != "/") {
 
-        if (!tmp.status) return {};
+            tmp = this->parsePath(dirname);
 
-        auto it = tmp.ptr->find(tmp.lastElement);
-        if (it == tmp.ptr->end()) return {};
+            if (!tmp.status) return {};
 
-        tmp.ptr = std::any_cast<std::shared_ptr<blazefs::internal::fs_map>>(
-            it->second);
+            auto it = tmp.ptr->find(tmp.lastElement);
+            if (it == tmp.ptr->end()) return {};
+
+            tmp.ptr = std::any_cast<std::shared_ptr<blaze::internal::fs_map>>(
+                it->second);
+        } else tmp.ptr = vfs_ptr;
 
         auto ret = std::make_unique<std::vector<std::string>>();
         ret->reserve(2048);
@@ -371,7 +377,7 @@ namespace blazefs {
 
         tmp_from.ptr->emplace(
             tmp_from.lastElement,
-            std::any_cast<std::shared_ptr<blazefs::internal::fs_map>>(
+            std::any_cast<std::shared_ptr<blaze::internal::fs_map>>(
                 it_to->second));
 
         return true;
@@ -415,8 +421,8 @@ namespace blazefs {
         if (tmp.lastElement[tmp.lastElement.length() - 1] != DIR_SEPARATOR)
             return false;
 
-        std::any_cast<std::shared_ptr<blazefs::internal::fs_map>>(it->second)
+        std::any_cast<std::shared_ptr<blaze::internal::fs_map>>(it->second)
             ->reserve(size);
         return true;
     }
-}; // namespace blazefs
+}; // namespace blaze

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(GTest::GTest INTERFACE gtest_main)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(BINARY ${CMAKE_PROJECT_NAME}_tests)
+set(BINARY BlazeFS_tests)
 file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false *.h *.cpp)
 set(SOURCES ${TEST_SOURCES})
 add_executable(${BINARY} ${TEST_SOURCES})

--- a/tests/cd.cpp
+++ b/tests/cd.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(cdTest, cdTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
     filesystem.createDir("dir/");
     filesystem.write("/test_file", std::string("some data"));
     filesystem.write("/dir/test_file", std::string("another data"));

--- a/tests/create_dir.cpp
+++ b/tests/create_dir.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(createDirTest, createDirTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
 
     ASSERT_EQ(true, filesystem.createDir("/dir/"));
     ASSERT_EQ(true, filesystem.createDir("dir1/"));

--- a/tests/create_symlink.cpp
+++ b/tests/create_symlink.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(createSymlinkTest, createSymlinkTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
 
     filesystem.createDir("dir/");
     filesystem.write("/dir/file", std::string("some data"));

--- a/tests/exists.cpp
+++ b/tests/exists.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(existsTest, existsTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
     filesystem.createDir("dir/");
     filesystem.write("/test_file", std::string("some data"));
 

--- a/tests/is_directory.cpp
+++ b/tests/is_directory.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(isDirectoryTest, isDirectoryTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
 
     filesystem.createDir("/dir/");
     filesystem.write("file", std::string("some data"));

--- a/tests/list_dir.cpp
+++ b/tests/list_dir.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <vector>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(listDirTest, listDirTest) {
@@ -15,7 +15,7 @@ TEST(listDirTest, listDirTest) {
     vec.emplace_back("dir1/");
     vec.emplace_back("dir2/");
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
 
     filesystem.createDir("/dir/");
     filesystem.createDir("dir/dir1/");

--- a/tests/read.cpp
+++ b/tests/read.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(readTest, readTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
     filesystem.write("/test_file", std::string("some data"));
 
     ASSERT_EQ("some data", filesystem.read<std::string>("/test_file"));

--- a/tests/remove.cpp
+++ b/tests/remove.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(removeTest, removeTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
     filesystem.createDir("dir/");
     filesystem.write("/test_file", std::string("some data"));
 

--- a/tests/reserve.cpp
+++ b/tests/reserve.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(reserveTest, reserveTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
 
     filesystem.createDir("/dir/");
 

--- a/tests/write.cpp
+++ b/tests/write.cpp
@@ -1,11 +1,11 @@
 #include <string>
 #include "gtest/gtest.h"
-#include "BlazeFS/BlazeFS.hpp"
+#include "blaze/BlazeFS/BlazeFS.hpp"
 
 
 TEST(writeTest, writeTest) {
 
-    blazefs::BlazeFS filesystem;
+    blaze::BlazeFS filesystem;
     ASSERT_EQ(true, filesystem.write("/test_file", std::string("some data")));
     ASSERT_EQ(true, filesystem.write("./test_file1", std::string("some data")));
     ASSERT_EQ(true,


### PR DESCRIPTION
# Description

This pull request may be considered as BlazeFS v1.0.0

- Closes #5
- Namespaces were renamed to match style of all blaze libraries
- `mimalloc` was deleted as unnecessary dependency
- Update documentation

### What kind of change does this PR introduce?

- [x] Bugfix
- [x] Docs

### Does this PR introduce a breaking change?

- [x] Yes, namespaces were renamed to match style of all blaze libraries
